### PR TITLE
Added 1073 to manufacturer id - driver.compose - 1402756

### DIFF
--- a/drivers/1402756/driver.compose.json
+++ b/drivers/1402756/driver.compose.json
@@ -26,6 +26,7 @@
   "zwave": {
     "manufacturerId": [
       816,
+      1073,
       1080
     ],
     "productTypeId": [


### PR DESCRIPTION
Some Namron z-wave dimmers have been shipped with 1073 as manufacturer id. Sp please add this so users can use the Namron app for this device :-)